### PR TITLE
Added uploadDownsize()

### DIFF
--- a/src/JIC.js
+++ b/src/JIC.js
@@ -117,5 +117,103 @@ var jic = {
             };
 
 
+        },      
+        
+	uploadDownsize: function(compressed_img_obj, upload_url, file_input_name, filename,  successCallback, errorCallback, duringCallback, width, height, quality,  output_format, customHeaders){
+	    	                 
+            var mime_type = "image/jpeg";
+             if(typeof output_format !== "undefined" && output_format=="png"){
+                mime_type = "image/png";
+             } 
+	    
+	    var cvs = document.createElement('canvas');
+	    
+	    // keep aspect ratio
+	    if (width==undefined || width==0)  {
+		width=compressed_img_obj.naturalWidth;		
+	    } else
+	    if (height==undefined || height==0)  {
+		height=compressed_img_obj.naturalHeight;		
+	    }	    
+	    
+	    var scale = Math.min(width / compressed_img_obj.naturalWidth , height / compressed_img_obj.naturalHeight);
+	    
+	    if (scale<1) {//downsize only
+		width=compressed_img_obj.naturalWidth * scale;
+		height=compressed_img_obj.naturalHeight * scale;
+	    } else {
+		width = compressed_img_obj.naturalWidth;
+		height = compressed_img_obj.naturalHeight;		
+	    }
+	    
+	    cvs.width=width;
+	    cvs.height=height;
+	    
+	    var ctx = cvs.getContext("2d").drawImage(compressed_img_obj, 0, 0,width, height);
+	    
+	    
+	    //quality modification   
+	    var newImageData = cvs.toDataURL(mime_type, quality/100);
+	    var result_image_obj = new Image();
+	    result_image_obj.src = newImageData;
+	    var ctx = cvs.getContext("2d").drawImage(result_image_obj, 0, 0,width, height);
+	    
+	    
+            //ADD sendAsBinary compatibilty to older browsers
+            if (XMLHttpRequest.prototype.sendAsBinary === undefined) {
+                XMLHttpRequest.prototype.sendAsBinary = function(string) {
+                    var bytes = Array.prototype.map.call(string, function(c) {
+                        return c.charCodeAt(0) & 0xff;
+                    });
+                    this.send(new Uint8Array(bytes).buffer);
+                };
+            }
+
+            var type = "image/jpeg";
+            if(filename.substr(-4)==".png"){
+                type = "image/png";
+            }
+
+            var data = cvs.toDataURL(type);
+            data = data.replace('data:' + type + ';base64,', '');
+            
+            var xhr = new XMLHttpRequest();
+            xhr.open('POST', upload_url, true);
+            var boundary = 'someboundary';
+
+            xhr.setRequestHeader('Content-Type', 'multipart/form-data; boundary=' + boundary);
+		
+		// Set custom request headers if customHeaders parameter is provided
+		if (customHeaders && typeof customHeaders === "object") {
+			for (var headerKey in customHeaders){
+				xhr.setRequestHeader(headerKey, customHeaders[headerKey]);
+			}
+		}
+		
+		// If a duringCallback function is set as a parameter, call that to notify about the upload progress
+		if (duringCallback && duringCallback instanceof Function) {
+			xhr.onprogress = function (evt) {
+				if (evt.lengthComputable) {  
+					return (evt.loaded / evt.total)*100;  
+				}
+			};
+		}
+		
+            xhr.sendAsBinary(['--' + boundary, 'Content-Disposition: form-data; name="' + file_input_name + '"; filename="' + filename + '"', 'Content-Type: ' + type, '', atob(data), '--' + boundary + '--'].join('\r\n'));
+            
+            xhr.onreadystatechange = function() {
+			if (this.readyState == 4){
+				if (this.status == 200) {
+					successCallback(this.responseText);
+				}else if (this.status >= 400) {
+					if (errorCallback &&  errorCallback instanceof Function) {
+						errorCallback(this.responseText);
+					}
+				}
+			}
+            };
+
+
         }
+        
 };


### PR DESCRIPTION
Added uploadDownsize() function to proportionally reduce (if needed) the size of the image in terms of pixels and to compress it in terms of quality before upload.
Scope is trying to minimize the bandwidth usage and server workload to accomplish same task.

A recursive function to match a wanted filesize would be very nice...
