### PR TITLE
Uppercase PNG extensions cause Error on upload

### DIFF
--- a/src/JIC.js
+++ b/src/JIC.js
@@ -67,7 +67,7 @@ var jic = {
             }
 
             var type = "image/jpeg";
-            if(filename.substr(-4)==".png"){
+            if(filename.substr(-4).toLowerCase()==".png"){
                 type = "image/png";
             }
 


### PR DESCRIPTION
I'm working on a modified code and i pass original filename to jic.upload()
Problem is if PNG extension is uppercase the line 70 fails to set mimetype and tries to process a png image as a jpeg. As a result it fires the error below.
Uncaught InvalidCharacterError: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.
So i modified line 70 to lowercase extension.