### PR TITLE
Adding support for webp format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # J I C 
-**J I C** is a Javascript Image Compressor using HTML5 Canvas & File API that allows you to compress your jpeg & png images before uploading to the server (100% client-side and no extra libraries requried!)
+**J I C** is a Javascript Image Compressor using HTML5 Canvas & File API that allows you to compress your jpeg, png, and webp images before uploading to the server (100% client-side and no extra libraries requried!)
 
 Could you imagine how much bandwidth we can save if Google, Twitter and r Facebook implement this image compression before we upload those 5MB photos? This approach will make the internet faster!!
 
@@ -46,7 +46,7 @@ var source_img = document.getElementById("source_img"),
 
 //An Integer from 0 to 100
 var quality =  80,
-// output file format (jpg || png)
+// output file format (jpg || png || webp)
 output_format = 'jpg', 
 //This function returns an Image Object 
 target_img.src = jic.compress(source_img,quality,output_format).src;  

--- a/src/JIC.js
+++ b/src/JIC.js
@@ -26,11 +26,14 @@ var jic = {
 
         compress: function(source_img_obj, quality, output_format){
              
-             var mime_type = "image/jpeg";
-             if(typeof output_format !== "undefined" && output_format=="png"){
+             var mime_type;
+             if(output_format=="png"){
                 mime_type = "image/png";
+             } else if(output_format=="webp") {
+                mime_type = "image/webp";
+             } else {
+                mime_type = "image/jpeg";
              }
-             
 
              var cvs = document.createElement('canvas');
              cvs.width = source_img_obj.naturalWidth;
@@ -66,9 +69,13 @@ var jic = {
                 };
             }
 
-            var type = "image/jpeg";
+            var type;
             if(filename.substr(-4).toLowerCase()==".png"){
                 type = "image/png";
+            } else if(filename.substr(-5).toLowerCase()==".webp") {
+                type = "image/webp";
+            } else {
+                type = "image/jpeg";
             }
 
             var data = compressed_img_obj.src;

--- a/src/JIC.js
+++ b/src/JIC.js
@@ -27,9 +27,9 @@ var jic = {
         compress: function(source_img_obj, quality, output_format){
              
              var mime_type;
-             if(output_format=="png"){
+             if(output_format==="png"){
                 mime_type = "image/png";
-             } else if(output_format=="webp") {
+             } else if(output_format==="webp") {
                 mime_type = "image/webp";
              } else {
                 mime_type = "image/jpeg";
@@ -70,9 +70,9 @@ var jic = {
             }
 
             var type;
-            if(filename.substr(-4).toLowerCase()==".png"){
+            if(filename.substr(-4).toLowerCase()===".png"){
                 type = "image/png";
-            } else if(filename.substr(-5).toLowerCase()==".webp") {
+            } else if(filename.substr(-5).toLowerCase()===".webp") {
                 type = "image/webp";
             } else {
                 type = "image/jpeg";

--- a/src/JIC.js
+++ b/src/JIC.js
@@ -17,10 +17,10 @@
 
 var jic = {
         /**
-         * Receives an Image Object (can be JPG OR PNG) and returns a new Image Object compressed
+         * Receives an Image Object (can be JPG, PNG, or WEBP) and returns a new Image Object compressed
          * @param {Image} source_img_obj The source Image Object
          * @param {Integer} quality The output quality of Image Object
-         * @param {String} output format. Possible values are jpg and png
+         * @param {String} output format. Possible values are jpg, png, and webp
          * @return {Image} result_image_obj The compressed Image Object
          */
 


### PR DESCRIPTION
Several browsers like Chrome and Opera already offer support for displaying and saving webp images. These changes enable using the webp format.